### PR TITLE
Displays only active contests in the admin payments screen

### DIFF
--- a/components/auth/admin/payments/Drawer/index.tsx
+++ b/components/auth/admin/payments/Drawer/index.tsx
@@ -179,7 +179,17 @@ const Drawer = ({
 		() => getRequest({ url: GET_CONTESTS }),
 		{
 			onSuccess(data) {
-				setContests(data?.data || []);
+				if (data?.data) {
+					const activeContests = [];
+
+					for (const item of data.data) {
+						if (item?.isActive) {
+							activeContests.push(item);
+						}
+					}
+
+					setContests(activeContests);
+				}
 			},
 			onError(error: any) {
 				console.error(error?.response);


### PR DESCRIPTION
**What does this PR do?**

- Displays only active contests in the payments screen for admin